### PR TITLE
Revert "[updatecli] Bump Fleet charts to 0.8.1"

### DIFF
--- a/charts/fleet-agent/Chart.yaml
+++ b/charts/fleet-agent/Chart.yaml
@@ -6,8 +6,8 @@ annotations:
   catalog.cattle.io/permits-os: linux,windows
   catalog.cattle.io/release-name: fleet-agent
 apiVersion: v2
-appVersion: 0.8.1
+appVersion: 0.9.0
 description: Fleet Manager Agent - GitOps at Scale
 icon: https://charts.rancher.io/assets/logos/fleet.svg
 name: fleet-agent
-version: 0.8.1
+version: 0.9.0

--- a/charts/fleet-agent/templates/rbac.yaml
+++ b/charts/fleet-agent/templates/rbac.yaml
@@ -9,7 +9,10 @@ rules:
   - '*'
   verbs:
   - '*'
-
+- nonResourceURLs:
+  - "*"
+  verbs:
+  - "*"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/fleet-agent/values.yaml
+++ b/charts/fleet-agent/values.yaml
@@ -1,7 +1,7 @@
 image:
   os: "windows,linux"
   repository: rancher/fleet-agent
-  tag: v0.8.1
+  tag: v0.9.0
 
 # The public URL of the Kubernetes API server running the Fleet Manager must be set here
 # Example: https://example.com:6443

--- a/charts/fleet-crd/Chart.yaml
+++ b/charts/fleet-crd/Chart.yaml
@@ -6,8 +6,8 @@ annotations:
   catalog.cattle.io/permits-os: linux,windows
   catalog.cattle.io/release-name: fleet-crd
 apiVersion: v2
-appVersion: 0.8.1
+appVersion: 0.9.0
 description: Fleet Manager CustomResourceDefinitions
 icon: https://charts.rancher.io/assets/logos/fleet.svg
 name: fleet-crd
-version: 0.8.1
+version: 0.9.0

--- a/charts/fleet-crd/templates/crds.yaml
+++ b/charts/fleet-crd/templates/crds.yaml
@@ -126,6 +126,8 @@ spec:
                   chart:
                     nullable: true
                     type: string
+                  disableDNS:
+                    type: boolean
                   disablePreProcess:
                     type: boolean
                   force:
@@ -140,6 +142,8 @@ spec:
                   repo:
                     nullable: true
                     type: string
+                  skipSchemaValidation:
+                    type: boolean
                   takeOwnership:
                     type: boolean
                   timeoutSeconds:
@@ -538,6 +542,8 @@ spec:
                         chart:
                           nullable: true
                           type: string
+                        disableDNS:
+                          type: boolean
                         disablePreProcess:
                           type: boolean
                         force:
@@ -550,6 +556,8 @@ spec:
                         repo:
                           nullable: true
                           type: string
+                        skipSchemaValidation:
+                          type: boolean
                         takeOwnership:
                           type: boolean
                         timeoutSeconds:
@@ -1095,6 +1103,8 @@ spec:
                       chart:
                         nullable: true
                         type: string
+                      disableDNS:
+                        type: boolean
                       disablePreProcess:
                         type: boolean
                       force:
@@ -1109,6 +1119,8 @@ spec:
                       repo:
                         nullable: true
                         type: string
+                      skipSchemaValidation:
+                        type: boolean
                       takeOwnership:
                         type: boolean
                       timeoutSeconds:
@@ -1283,6 +1295,8 @@ spec:
                       chart:
                         nullable: true
                         type: string
+                      disableDNS:
+                        type: boolean
                       disablePreProcess:
                         type: boolean
                       force:
@@ -1295,6 +1309,8 @@ spec:
                       repo:
                         nullable: true
                         type: string
+                      skipSchemaValidation:
+                        type: boolean
                       takeOwnership:
                         type: boolean
                       timeoutSeconds:
@@ -2435,6 +2451,15 @@ spec:
               agentResources:
                 nullable: true
                 properties:
+                  claims:
+                    items:
+                      properties:
+                        name:
+                          nullable: true
+                          type: string
+                      type: object
+                    nullable: true
+                    type: array
                   limits:
                     additionalProperties:
                       nullable: true
@@ -2474,6 +2499,9 @@ spec:
                 nullable: true
                 type: string
               kubeConfigSecret:
+                nullable: true
+                type: string
+              kubeConfigSecretNamespace:
                 nullable: true
                 type: string
               paused:

--- a/charts/fleet/Chart.yaml
+++ b/charts/fleet/Chart.yaml
@@ -9,13 +9,13 @@ annotations:
   catalog.cattle.io/provides-gvr: clusters.fleet.cattle.io/v1alpha1
   catalog.cattle.io/release-name: fleet
 apiVersion: v2
-appVersion: 0.8.1
+appVersion: 0.9.0
 dependencies:
 - condition: gitops.enabled
   name: gitjob
   repository: file://./charts/gitjob
-  version: 0.1.76-security1
+  version: 0.1.96
 description: Fleet Manager - GitOps at Scale
 icon: https://charts.rancher.io/assets/logos/fleet.svg
 name: fleet
-version: 0.8.1
+version: 0.9.0

--- a/charts/fleet/charts/gitjob/Chart.yaml
+++ b/charts/fleet/charts/gitjob/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.1.76-security1
+appVersion: 0.1.96
 description: Controller that run jobs based on git events
 name: gitjob
-version: 0.1.76-security1
+version: 0.1.96

--- a/charts/fleet/charts/gitjob/templates/deployment.yaml
+++ b/charts/fleet/charts/gitjob/templates/deployment.yaml
@@ -16,11 +16,12 @@ spec:
         - image: "{{ template "system_default_registry" . }}{{ .Values.gitjob.repository }}:{{ .Values.gitjob.tag }}"
           name: gitjob
           args:
+          - gitjob
+          - --gitjob-image
+          - "{{ template "system_default_registry" . }}{{ .Values.gitjob.repository }}:{{ .Values.gitjob.tag }}"
           {{- if .Values.debug }}
           - --debug
           {{- end }}
-          - --tekton-image
-          - "{{ template "system_default_registry" . }}{{ .Values.tekton.repository }}:{{ .Values.tekton.tag }}"
           env:
             - name: NAMESPACE
               valueFrom:

--- a/charts/fleet/charts/gitjob/values.yaml
+++ b/charts/fleet/charts/gitjob/values.yaml
@@ -1,10 +1,6 @@
 gitjob:
   repository: rancher/gitjob
-  tag: v0.1.76-security1
-
-tekton:
-  repository: rancher/tekton-utils
-  tag: v0.1.37
+  tag: v0.1.96
 
 global:
   cattle:

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -1,11 +1,11 @@
 image:
   repository: rancher/fleet
-  tag: v0.8.1
+  tag: v0.9.0
   imagePullPolicy: IfNotPresent
 
 agentImage:
   repository: rancher/fleet-agent
-  tag: v0.8.1
+  tag: v0.9.0
   imagePullPolicy: IfNotPresent
 
 # For cluster registration the public URL of the Kubernetes API server must be set here


### PR DESCRIPTION
Reverts rancher/fleet-helm-charts#20 to set Fleet 0.9.0 as the latest chart again after Fleet 0.8.1 was picked up by the release action.