### PR TITLE
fix: use latest semantic version

### DIFF
--- a/updatecli/updatecli.d/fleet.yaml
+++ b/updatecli/updatecli.d/fleet.yaml
@@ -1,4 +1,4 @@
-title: Bump Fleet Helm Charts
+name: Bump Fleet Helm Charts
 
 scms:
   fleethelmcharts:
@@ -21,6 +21,8 @@ sources:
       repository: fleet
       token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
       username: '{{ requiredEnv "UPDATECLI_GITHUB_ACTOR" }}'
+      versionfilter:
+        kind: "semver"
       typefilter:
         prerelease: true
         release: true


### PR DESCRIPTION
In the current configuration, Updatecli monitor the "latest" version published on GitHub Release but because Fleet maintains multiple release line, sometimes Updatecli proposes an older version from an semantic versioning perspective.

So this pull request explicitly mention to use the latest from a semantic versioning perspective