### PR TITLE
Bump Fleet charts to 0.8.2-rc.3

### DIFF
--- a/charts/fleet-agent/Chart.yaml
+++ b/charts/fleet-agent/Chart.yaml
@@ -6,8 +6,8 @@ annotations:
   catalog.cattle.io/permits-os: linux,windows
   catalog.cattle.io/release-name: fleet-agent
 apiVersion: v2
-appVersion: 0.9.1-rc.2
+appVersion: 0.8.2-rc.3
 description: Fleet Manager Agent - GitOps at Scale
 icon: https://charts.rancher.io/assets/logos/fleet.svg
 name: fleet-agent
-version: 0.9.1-rc.2
+version: 0.8.2-rc.3

--- a/charts/fleet-agent/templates/rbac.yaml
+++ b/charts/fleet-agent/templates/rbac.yaml
@@ -9,10 +9,7 @@ rules:
   - '*'
   verbs:
   - '*'
-- nonResourceURLs:
-  - "*"
-  verbs:
-  - "*"
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/fleet-agent/values.yaml
+++ b/charts/fleet-agent/values.yaml
@@ -1,7 +1,7 @@
 image:
   os: "windows,linux"
   repository: rancher/fleet-agent
-  tag: v0.9.1-rc.2
+  tag: v0.8.2-rc.3
 
 # The public URL of the Kubernetes API server running the Fleet Manager must be set here
 # Example: https://example.com:6443

--- a/charts/fleet-crd/Chart.yaml
+++ b/charts/fleet-crd/Chart.yaml
@@ -6,8 +6,8 @@ annotations:
   catalog.cattle.io/permits-os: linux,windows
   catalog.cattle.io/release-name: fleet-crd
 apiVersion: v2
-appVersion: 0.9.1-rc.2
+appVersion: 0.8.2-rc.3
 description: Fleet Manager CustomResourceDefinitions
 icon: https://charts.rancher.io/assets/logos/fleet.svg
 name: fleet-crd
-version: 0.9.1-rc.2
+version: 0.8.2-rc.3

--- a/charts/fleet-crd/templates/crds.yaml
+++ b/charts/fleet-crd/templates/crds.yaml
@@ -25,7 +25,6 @@ spec:
           spec:
             properties:
               correctDrift:
-                nullable: true
                 properties:
                   enabled:
                     type: boolean
@@ -37,8 +36,6 @@ spec:
               defaultNamespace:
                 nullable: true
                 type: string
-              deleteCRDResources:
-                type: boolean
               dependsOn:
                 items:
                   properties:
@@ -129,8 +126,6 @@ spec:
                   chart:
                     nullable: true
                     type: string
-                  disableDNS:
-                    type: boolean
                   disablePreProcess:
                     type: boolean
                   force:
@@ -145,8 +140,6 @@ spec:
                   repo:
                     nullable: true
                     type: string
-                  skipSchemaValidation:
-                    type: boolean
                   takeOwnership:
                     type: boolean
                   timeoutSeconds:
@@ -257,13 +250,13 @@ spec:
                 properties:
                   autoPartitionSize:
                     nullable: true
-                    x-kubernetes-int-or-string: true
+                    type: string
                   maxUnavailable:
                     nullable: true
-                    x-kubernetes-int-or-string: true
+                    type: string
                   maxUnavailablePartitions:
                     nullable: true
-                    x-kubernetes-int-or-string: true
+                    type: string
                   partitions:
                     items:
                       properties:
@@ -331,7 +324,7 @@ spec:
                           type: object
                         maxUnavailable:
                           nullable: true
-                          x-kubernetes-int-or-string: true
+                          type: string
                         name:
                           nullable: true
                           type: string
@@ -479,7 +472,6 @@ spec:
                           type: object
                       type: object
                     correctDrift:
-                      nullable: true
                       properties:
                         enabled:
                           type: boolean
@@ -491,8 +483,6 @@ spec:
                     defaultNamespace:
                       nullable: true
                       type: string
-                    deleteCRDResources:
-                      type: boolean
                     diff:
                       nullable: true
                       properties:
@@ -548,8 +538,6 @@ spec:
                         chart:
                           nullable: true
                           type: string
-                        disableDNS:
-                          type: boolean
                         disablePreProcess:
                           type: boolean
                         force:
@@ -562,8 +550,6 @@ spec:
                         repo:
                           nullable: true
                           type: string
-                        skipSchemaValidation:
-                          type: boolean
                         takeOwnership:
                           type: boolean
                         timeoutSeconds:
@@ -994,7 +980,6 @@ spec:
           spec:
             properties:
               correctDrift:
-                nullable: true
                 properties:
                   enabled:
                     type: boolean
@@ -1046,7 +1031,6 @@ spec:
               options:
                 properties:
                   correctDrift:
-                    nullable: true
                     properties:
                       enabled:
                         type: boolean
@@ -1058,8 +1042,6 @@ spec:
                   defaultNamespace:
                     nullable: true
                     type: string
-                  deleteCRDResources:
-                    type: boolean
                   diff:
                     nullable: true
                     properties:
@@ -1113,8 +1095,6 @@ spec:
                       chart:
                         nullable: true
                         type: string
-                      disableDNS:
-                        type: boolean
                       disablePreProcess:
                         type: boolean
                       force:
@@ -1129,8 +1109,6 @@ spec:
                       repo:
                         nullable: true
                         type: string
-                      skipSchemaValidation:
-                        type: boolean
                       takeOwnership:
                         type: boolean
                       timeoutSeconds:
@@ -1241,7 +1219,6 @@ spec:
               stagedOptions:
                 properties:
                   correctDrift:
-                    nullable: true
                     properties:
                       enabled:
                         type: boolean
@@ -1253,8 +1230,6 @@ spec:
                   defaultNamespace:
                     nullable: true
                     type: string
-                  deleteCRDResources:
-                    type: boolean
                   diff:
                     nullable: true
                     properties:
@@ -1308,8 +1283,6 @@ spec:
                       chart:
                         nullable: true
                         type: string
-                      disableDNS:
-                        type: boolean
                       disablePreProcess:
                         type: boolean
                       force:
@@ -1322,8 +1295,6 @@ spec:
                       repo:
                         nullable: true
                         type: string
-                      skipSchemaValidation:
-                        type: boolean
                       takeOwnership:
                         type: boolean
                       timeoutSeconds:
@@ -2514,9 +2485,6 @@ spec:
               kubeConfigSecret:
                 nullable: true
                 type: string
-              kubeConfigSecretNamespace:
-                nullable: true
-                type: string
               paused:
                 type: boolean
               privateRepoURL:
@@ -2851,7 +2819,6 @@ spec:
                 nullable: true
                 type: string
               correctDrift:
-                nullable: true
                 properties:
                   enabled:
                     type: boolean

--- a/charts/fleet-crd/templates/gitjobs-crds.yaml
+++ b/charts/fleet-crd/templates/gitjobs-crds.yaml
@@ -70,9 +70,6 @@ spec:
                   backoffLimit:
                     nullable: true
                     type: integer
-                  backoffLimitPerIndex:
-                    nullable: true
-                    type: integer
                   completionMode:
                     nullable: true
                     type: string
@@ -82,9 +79,6 @@ spec:
                   manualSelector:
                     nullable: true
                     type: boolean
-                  maxFailedIndexes:
-                    nullable: true
-                    type: integer
                   parallelism:
                     nullable: true
                     type: integer
@@ -128,9 +122,6 @@ spec:
                         nullable: true
                         type: array
                     type: object
-                  podReplacementPolicy:
-                    nullable: true
-                    type: string
                   selector:
                     nullable: true
                     properties:
@@ -829,7 +820,8 @@ spec:
                                               nullable: true
                                               type: string
                                             port:
-                                              x-kubernetes-int-or-string: true
+                                              nullable: true
+                                              type: string
                                             scheme:
                                               nullable: true
                                               type: string
@@ -841,7 +833,8 @@ spec:
                                               nullable: true
                                               type: string
                                             port:
-                                              x-kubernetes-int-or-string: true
+                                              nullable: true
+                                              type: string
                                           type: object
                                       type: object
                                     preStop:
@@ -879,7 +872,8 @@ spec:
                                               nullable: true
                                               type: string
                                             port:
-                                              x-kubernetes-int-or-string: true
+                                              nullable: true
+                                              type: string
                                             scheme:
                                               nullable: true
                                               type: string
@@ -891,7 +885,8 @@ spec:
                                               nullable: true
                                               type: string
                                             port:
-                                              x-kubernetes-int-or-string: true
+                                              nullable: true
+                                              type: string
                                           type: object
                                       type: object
                                   type: object
@@ -941,7 +936,8 @@ spec:
                                           nullable: true
                                           type: string
                                         port:
-                                          x-kubernetes-int-or-string: true
+                                          nullable: true
+                                          type: string
                                         scheme:
                                           nullable: true
                                           type: string
@@ -959,7 +955,8 @@ spec:
                                           nullable: true
                                           type: string
                                         port:
-                                          x-kubernetes-int-or-string: true
+                                          nullable: true
+                                          type: string
                                       type: object
                                     terminationGracePeriodSeconds:
                                       nullable: true
@@ -1035,7 +1032,8 @@ spec:
                                           nullable: true
                                           type: string
                                         port:
-                                          x-kubernetes-int-or-string: true
+                                          nullable: true
+                                          type: string
                                         scheme:
                                           nullable: true
                                           type: string
@@ -1053,7 +1051,8 @@ spec:
                                           nullable: true
                                           type: string
                                         port:
-                                          x-kubernetes-int-or-string: true
+                                          nullable: true
+                                          type: string
                                       type: object
                                     terminationGracePeriodSeconds:
                                       nullable: true
@@ -1097,9 +1096,6 @@ spec:
                                       nullable: true
                                       type: object
                                   type: object
-                                restartPolicy:
-                                  nullable: true
-                                  type: string
                                 securityContext:
                                   nullable: true
                                   properties:
@@ -1229,7 +1225,8 @@ spec:
                                           nullable: true
                                           type: string
                                         port:
-                                          x-kubernetes-int-or-string: true
+                                          nullable: true
+                                          type: string
                                         scheme:
                                           nullable: true
                                           type: string
@@ -1247,7 +1244,8 @@ spec:
                                           nullable: true
                                           type: string
                                         port:
-                                          x-kubernetes-int-or-string: true
+                                          nullable: true
+                                          type: string
                                       type: object
                                     terminationGracePeriodSeconds:
                                       nullable: true
@@ -1495,7 +1493,8 @@ spec:
                                               nullable: true
                                               type: string
                                             port:
-                                              x-kubernetes-int-or-string: true
+                                              nullable: true
+                                              type: string
                                             scheme:
                                               nullable: true
                                               type: string
@@ -1507,7 +1506,8 @@ spec:
                                               nullable: true
                                               type: string
                                             port:
-                                              x-kubernetes-int-or-string: true
+                                              nullable: true
+                                              type: string
                                           type: object
                                       type: object
                                     preStop:
@@ -1545,7 +1545,8 @@ spec:
                                               nullable: true
                                               type: string
                                             port:
-                                              x-kubernetes-int-or-string: true
+                                              nullable: true
+                                              type: string
                                             scheme:
                                               nullable: true
                                               type: string
@@ -1557,7 +1558,8 @@ spec:
                                               nullable: true
                                               type: string
                                             port:
-                                              x-kubernetes-int-or-string: true
+                                              nullable: true
+                                              type: string
                                           type: object
                                       type: object
                                   type: object
@@ -1607,7 +1609,8 @@ spec:
                                           nullable: true
                                           type: string
                                         port:
-                                          x-kubernetes-int-or-string: true
+                                          nullable: true
+                                          type: string
                                         scheme:
                                           nullable: true
                                           type: string
@@ -1625,7 +1628,8 @@ spec:
                                           nullable: true
                                           type: string
                                         port:
-                                          x-kubernetes-int-or-string: true
+                                          nullable: true
+                                          type: string
                                       type: object
                                     terminationGracePeriodSeconds:
                                       nullable: true
@@ -1701,7 +1705,8 @@ spec:
                                           nullable: true
                                           type: string
                                         port:
-                                          x-kubernetes-int-or-string: true
+                                          nullable: true
+                                          type: string
                                         scheme:
                                           nullable: true
                                           type: string
@@ -1719,7 +1724,8 @@ spec:
                                           nullable: true
                                           type: string
                                         port:
-                                          x-kubernetes-int-or-string: true
+                                          nullable: true
+                                          type: string
                                       type: object
                                     terminationGracePeriodSeconds:
                                       nullable: true
@@ -1763,9 +1769,6 @@ spec:
                                       nullable: true
                                       type: object
                                   type: object
-                                restartPolicy:
-                                  nullable: true
-                                  type: string
                                 securityContext:
                                   nullable: true
                                   properties:
@@ -1895,7 +1898,8 @@ spec:
                                           nullable: true
                                           type: string
                                         port:
-                                          x-kubernetes-int-or-string: true
+                                          nullable: true
+                                          type: string
                                         scheme:
                                           nullable: true
                                           type: string
@@ -1913,7 +1917,8 @@ spec:
                                           nullable: true
                                           type: string
                                         port:
-                                          x-kubernetes-int-or-string: true
+                                          nullable: true
+                                          type: string
                                       type: object
                                     terminationGracePeriodSeconds:
                                       nullable: true
@@ -2166,7 +2171,8 @@ spec:
                                               nullable: true
                                               type: string
                                             port:
-                                              x-kubernetes-int-or-string: true
+                                              nullable: true
+                                              type: string
                                             scheme:
                                               nullable: true
                                               type: string
@@ -2178,7 +2184,8 @@ spec:
                                               nullable: true
                                               type: string
                                             port:
-                                              x-kubernetes-int-or-string: true
+                                              nullable: true
+                                              type: string
                                           type: object
                                       type: object
                                     preStop:
@@ -2216,7 +2223,8 @@ spec:
                                               nullable: true
                                               type: string
                                             port:
-                                              x-kubernetes-int-or-string: true
+                                              nullable: true
+                                              type: string
                                             scheme:
                                               nullable: true
                                               type: string
@@ -2228,7 +2236,8 @@ spec:
                                               nullable: true
                                               type: string
                                             port:
-                                              x-kubernetes-int-or-string: true
+                                              nullable: true
+                                              type: string
                                           type: object
                                       type: object
                                   type: object
@@ -2278,7 +2287,8 @@ spec:
                                           nullable: true
                                           type: string
                                         port:
-                                          x-kubernetes-int-or-string: true
+                                          nullable: true
+                                          type: string
                                         scheme:
                                           nullable: true
                                           type: string
@@ -2296,7 +2306,8 @@ spec:
                                           nullable: true
                                           type: string
                                         port:
-                                          x-kubernetes-int-or-string: true
+                                          nullable: true
+                                          type: string
                                       type: object
                                     terminationGracePeriodSeconds:
                                       nullable: true
@@ -2372,7 +2383,8 @@ spec:
                                           nullable: true
                                           type: string
                                         port:
-                                          x-kubernetes-int-or-string: true
+                                          nullable: true
+                                          type: string
                                         scheme:
                                           nullable: true
                                           type: string
@@ -2390,7 +2402,8 @@ spec:
                                           nullable: true
                                           type: string
                                         port:
-                                          x-kubernetes-int-or-string: true
+                                          nullable: true
+                                          type: string
                                       type: object
                                     terminationGracePeriodSeconds:
                                       nullable: true
@@ -2434,9 +2447,6 @@ spec:
                                       nullable: true
                                       type: object
                                   type: object
-                                restartPolicy:
-                                  nullable: true
-                                  type: string
                                 securityContext:
                                   nullable: true
                                   properties:
@@ -2566,7 +2576,8 @@ spec:
                                           nullable: true
                                           type: string
                                         port:
-                                          x-kubernetes-int-or-string: true
+                                          nullable: true
+                                          type: string
                                         scheme:
                                           nullable: true
                                           type: string
@@ -2584,7 +2595,8 @@ spec:
                                           nullable: true
                                           type: string
                                         port:
-                                          x-kubernetes-int-or-string: true
+                                          nullable: true
+                                          type: string
                                       type: object
                                     terminationGracePeriodSeconds:
                                       nullable: true
@@ -3914,9 +3926,6 @@ spec:
                 backoffLimit:
                   nullable: true
                   type: integer
-                backoffLimitPerIndex:
-                  nullable: true
-                  type: integer
                 completionMode:
                   nullable: true
                   type: string
@@ -3926,9 +3935,6 @@ spec:
                 manualSelector:
                   nullable: true
                   type: boolean
-                maxFailedIndexes:
-                  nullable: true
-                  type: integer
                 parallelism:
                   nullable: true
                   type: integer
@@ -3972,9 +3978,6 @@ spec:
                       nullable: true
                       type: array
                   type: object
-                podReplacementPolicy:
-                  nullable: true
-                  type: string
                 selector:
                   nullable: true
                   properties:
@@ -4673,7 +4676,8 @@ spec:
                                             nullable: true
                                             type: string
                                           port:
-                                            x-kubernetes-int-or-string: true
+                                            nullable: true
+                                            type: string
                                           scheme:
                                             nullable: true
                                             type: string
@@ -4685,7 +4689,8 @@ spec:
                                             nullable: true
                                             type: string
                                           port:
-                                            x-kubernetes-int-or-string: true
+                                            nullable: true
+                                            type: string
                                         type: object
                                     type: object
                                   preStop:
@@ -4723,7 +4728,8 @@ spec:
                                             nullable: true
                                             type: string
                                           port:
-                                            x-kubernetes-int-or-string: true
+                                            nullable: true
+                                            type: string
                                           scheme:
                                             nullable: true
                                             type: string
@@ -4735,7 +4741,8 @@ spec:
                                             nullable: true
                                             type: string
                                           port:
-                                            x-kubernetes-int-or-string: true
+                                            nullable: true
+                                            type: string
                                         type: object
                                     type: object
                                 type: object
@@ -4785,7 +4792,8 @@ spec:
                                         nullable: true
                                         type: string
                                       port:
-                                        x-kubernetes-int-or-string: true
+                                        nullable: true
+                                        type: string
                                       scheme:
                                         nullable: true
                                         type: string
@@ -4803,7 +4811,8 @@ spec:
                                         nullable: true
                                         type: string
                                       port:
-                                        x-kubernetes-int-or-string: true
+                                        nullable: true
+                                        type: string
                                     type: object
                                   terminationGracePeriodSeconds:
                                     nullable: true
@@ -4879,7 +4888,8 @@ spec:
                                         nullable: true
                                         type: string
                                       port:
-                                        x-kubernetes-int-or-string: true
+                                        nullable: true
+                                        type: string
                                       scheme:
                                         nullable: true
                                         type: string
@@ -4897,7 +4907,8 @@ spec:
                                         nullable: true
                                         type: string
                                       port:
-                                        x-kubernetes-int-or-string: true
+                                        nullable: true
+                                        type: string
                                     type: object
                                   terminationGracePeriodSeconds:
                                     nullable: true
@@ -4941,9 +4952,6 @@ spec:
                                     nullable: true
                                     type: object
                                 type: object
-                              restartPolicy:
-                                nullable: true
-                                type: string
                               securityContext:
                                 nullable: true
                                 properties:
@@ -5073,7 +5081,8 @@ spec:
                                         nullable: true
                                         type: string
                                       port:
-                                        x-kubernetes-int-or-string: true
+                                        nullable: true
+                                        type: string
                                       scheme:
                                         nullable: true
                                         type: string
@@ -5091,7 +5100,8 @@ spec:
                                         nullable: true
                                         type: string
                                       port:
-                                        x-kubernetes-int-or-string: true
+                                        nullable: true
+                                        type: string
                                     type: object
                                   terminationGracePeriodSeconds:
                                     nullable: true
@@ -5339,7 +5349,8 @@ spec:
                                             nullable: true
                                             type: string
                                           port:
-                                            x-kubernetes-int-or-string: true
+                                            nullable: true
+                                            type: string
                                           scheme:
                                             nullable: true
                                             type: string
@@ -5351,7 +5362,8 @@ spec:
                                             nullable: true
                                             type: string
                                           port:
-                                            x-kubernetes-int-or-string: true
+                                            nullable: true
+                                            type: string
                                         type: object
                                     type: object
                                   preStop:
@@ -5389,7 +5401,8 @@ spec:
                                             nullable: true
                                             type: string
                                           port:
-                                            x-kubernetes-int-or-string: true
+                                            nullable: true
+                                            type: string
                                           scheme:
                                             nullable: true
                                             type: string
@@ -5401,7 +5414,8 @@ spec:
                                             nullable: true
                                             type: string
                                           port:
-                                            x-kubernetes-int-or-string: true
+                                            nullable: true
+                                            type: string
                                         type: object
                                     type: object
                                 type: object
@@ -5451,7 +5465,8 @@ spec:
                                         nullable: true
                                         type: string
                                       port:
-                                        x-kubernetes-int-or-string: true
+                                        nullable: true
+                                        type: string
                                       scheme:
                                         nullable: true
                                         type: string
@@ -5469,7 +5484,8 @@ spec:
                                         nullable: true
                                         type: string
                                       port:
-                                        x-kubernetes-int-or-string: true
+                                        nullable: true
+                                        type: string
                                     type: object
                                   terminationGracePeriodSeconds:
                                     nullable: true
@@ -5545,7 +5561,8 @@ spec:
                                         nullable: true
                                         type: string
                                       port:
-                                        x-kubernetes-int-or-string: true
+                                        nullable: true
+                                        type: string
                                       scheme:
                                         nullable: true
                                         type: string
@@ -5563,7 +5580,8 @@ spec:
                                         nullable: true
                                         type: string
                                       port:
-                                        x-kubernetes-int-or-string: true
+                                        nullable: true
+                                        type: string
                                     type: object
                                   terminationGracePeriodSeconds:
                                     nullable: true
@@ -5607,9 +5625,6 @@ spec:
                                     nullable: true
                                     type: object
                                 type: object
-                              restartPolicy:
-                                nullable: true
-                                type: string
                               securityContext:
                                 nullable: true
                                 properties:
@@ -5739,7 +5754,8 @@ spec:
                                         nullable: true
                                         type: string
                                       port:
-                                        x-kubernetes-int-or-string: true
+                                        nullable: true
+                                        type: string
                                       scheme:
                                         nullable: true
                                         type: string
@@ -5757,7 +5773,8 @@ spec:
                                         nullable: true
                                         type: string
                                       port:
-                                        x-kubernetes-int-or-string: true
+                                        nullable: true
+                                        type: string
                                     type: object
                                   terminationGracePeriodSeconds:
                                     nullable: true
@@ -6010,7 +6027,8 @@ spec:
                                             nullable: true
                                             type: string
                                           port:
-                                            x-kubernetes-int-or-string: true
+                                            nullable: true
+                                            type: string
                                           scheme:
                                             nullable: true
                                             type: string
@@ -6022,7 +6040,8 @@ spec:
                                             nullable: true
                                             type: string
                                           port:
-                                            x-kubernetes-int-or-string: true
+                                            nullable: true
+                                            type: string
                                         type: object
                                     type: object
                                   preStop:
@@ -6060,7 +6079,8 @@ spec:
                                             nullable: true
                                             type: string
                                           port:
-                                            x-kubernetes-int-or-string: true
+                                            nullable: true
+                                            type: string
                                           scheme:
                                             nullable: true
                                             type: string
@@ -6072,7 +6092,8 @@ spec:
                                             nullable: true
                                             type: string
                                           port:
-                                            x-kubernetes-int-or-string: true
+                                            nullable: true
+                                            type: string
                                         type: object
                                     type: object
                                 type: object
@@ -6122,7 +6143,8 @@ spec:
                                         nullable: true
                                         type: string
                                       port:
-                                        x-kubernetes-int-or-string: true
+                                        nullable: true
+                                        type: string
                                       scheme:
                                         nullable: true
                                         type: string
@@ -6140,7 +6162,8 @@ spec:
                                         nullable: true
                                         type: string
                                       port:
-                                        x-kubernetes-int-or-string: true
+                                        nullable: true
+                                        type: string
                                     type: object
                                   terminationGracePeriodSeconds:
                                     nullable: true
@@ -6216,7 +6239,8 @@ spec:
                                         nullable: true
                                         type: string
                                       port:
-                                        x-kubernetes-int-or-string: true
+                                        nullable: true
+                                        type: string
                                       scheme:
                                         nullable: true
                                         type: string
@@ -6234,7 +6258,8 @@ spec:
                                         nullable: true
                                         type: string
                                       port:
-                                        x-kubernetes-int-or-string: true
+                                        nullable: true
+                                        type: string
                                     type: object
                                   terminationGracePeriodSeconds:
                                     nullable: true
@@ -6278,9 +6303,6 @@ spec:
                                     nullable: true
                                     type: object
                                 type: object
-                              restartPolicy:
-                                nullable: true
-                                type: string
                               securityContext:
                                 nullable: true
                                 properties:
@@ -6410,7 +6432,8 @@ spec:
                                         nullable: true
                                         type: string
                                       port:
-                                        x-kubernetes-int-or-string: true
+                                        nullable: true
+                                        type: string
                                       scheme:
                                         nullable: true
                                         type: string
@@ -6428,7 +6451,8 @@ spec:
                                         nullable: true
                                         type: string
                                       port:
-                                        x-kubernetes-int-or-string: true
+                                        nullable: true
+                                        type: string
                                     type: object
                                   terminationGracePeriodSeconds:
                                     nullable: true

--- a/charts/fleet/Chart.yaml
+++ b/charts/fleet/Chart.yaml
@@ -9,13 +9,13 @@ annotations:
   catalog.cattle.io/provides-gvr: clusters.fleet.cattle.io/v1alpha1
   catalog.cattle.io/release-name: fleet
 apiVersion: v2
-appVersion: 0.9.1-rc.2
+appVersion: 0.8.2-rc.3
 dependencies:
 - condition: gitops.enabled
   name: gitjob
   repository: file://./charts/gitjob
-  version: 0.9.1
+  version: 0.8.1
 description: Fleet Manager - GitOps at Scale
 icon: https://charts.rancher.io/assets/logos/fleet.svg
 name: fleet
-version: 0.9.1-rc.2
+version: 0.8.2-rc.3

--- a/charts/fleet/charts/gitjob/Chart.yaml
+++ b/charts/fleet/charts/gitjob/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.9.1
+appVersion: 0.8.1
 description: Controller that run jobs based on git events
 name: gitjob
-version: 0.9.1
+version: 0.8.1

--- a/charts/fleet/charts/gitjob/templates/deployment.yaml
+++ b/charts/fleet/charts/gitjob/templates/deployment.yaml
@@ -16,12 +16,11 @@ spec:
         - image: "{{ template "system_default_registry" . }}{{ .Values.gitjob.repository }}:{{ .Values.gitjob.tag }}"
           name: gitjob
           args:
-          - gitjob
-          - --gitjob-image
-          - "{{ template "system_default_registry" . }}{{ .Values.gitjob.repository }}:{{ .Values.gitjob.tag }}"
           {{- if .Values.debug }}
           - --debug
           {{- end }}
+          - --tekton-image
+          - "{{ template "system_default_registry" . }}{{ .Values.tekton.repository }}:{{ .Values.tekton.tag }}"
           env:
             - name: NAMESPACE
               valueFrom:

--- a/charts/fleet/charts/gitjob/values.yaml
+++ b/charts/fleet/charts/gitjob/values.yaml
@@ -1,6 +1,10 @@
 gitjob:
   repository: rancher/gitjob
-  tag: v0.9.1
+  tag: v0.8.1
+
+tekton:
+  repository: rancher/tekton-utils
+  tag: v0.1.37
 
 global:
   cattle:

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -1,11 +1,11 @@
 image:
   repository: rancher/fleet
-  tag: v0.9.1-rc.2
+  tag: v0.8.2-rc.3
   imagePullPolicy: IfNotPresent
 
 agentImage:
   repository: rancher/fleet-agent
-  tag: v0.9.1-rc.2
+  tag: v0.8.2-rc.3
   imagePullPolicy: IfNotPresent
 
 # For cluster registration the public URL of the Kubernetes API server must be set here


### PR DESCRIPTION
make sure Fleet 0.8.2-rc.3 is also available because it was released during the updatecli configuration change.